### PR TITLE
Improve styling for Firebase songs section

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -273,7 +273,13 @@ input[type="range"]::-webkit-slider-thumb {
 /* Firebase */
 
 #songList {
-  margin-left: 40px;
+  margin: 40px;
+}
+
+#songList ul {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-around;
 }
 
 .songs {

--- a/index.html
+++ b/index.html
@@ -64,6 +64,7 @@
     </div>
     <div id='songList'>
       <h2>Firebase songs</h2>
+      <br>
     </div>
 
     <script src="notevalues.js"></script>


### PR DESCRIPTION
This PR improves styling for the `Firebase Songs` section.

## Before:
![Screenshot 2019-10-02 at 09 14 47](https://user-images.githubusercontent.com/19375569/66022126-a356b580-e4f5-11e9-8e1a-cd626d3fd077.png)
As the list of songs grows, users will have to scroll more and more.

## After:
![Screenshot 2019-10-02 at 09 14 33](https://user-images.githubusercontent.com/19375569/66022177-c2554780-e4f5-11e9-8f4b-5a555bbda255.png)
The songs are now arranged in a way that makes it easier to see and reduces scrolling.